### PR TITLE
1) Fix for Ubuntu 20.04, 2) Capability: CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  industrial_ci:
+    name: ROS2 (${{ matrix.env.ROS_DISTRO }})
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - {ROS_DISTRO: foxy, ROS_REPO: ros, ABICHECK_URL: "github:mikeferguson/simple_grasping#foxy-devel"}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{ matrix.env }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - {ROS_DISTRO: foxy, ROS_REPO: ros, ABICHECK_URL: "github:mikeferguson/simple_grasping#foxy-devel"}
+          #- {ROS_DISTRO: foxy, ROS_REPO: ros, ABICHECK_URL: "github:mikeferguson/simple_grasping#foxy-devel"}
+          - {ROS_DISTRO: foxy, ROS_REPO: ros, ABICHECK_URL: "github:130s/simple_grasping#galactic-devel"}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2

--- a/src/basic_grasping_perception.cpp
+++ b/src/basic_grasping_perception.cpp
@@ -75,6 +75,7 @@ public:
 
     // use_debug: enable/disable output of a cloud containing object points
     debug_ = this->declare_parameter<bool>("debug_topics", false);
+    topic_path_depth_ = this->declare_parameter("topic_path_depth", "/head_camera/depth_registered/points");
 
     // frame_id: frame to transform cloud to (should be XY horizontal)
     world_frame_ = this->declare_parameter<std::string>("frame_id", "base_link");
@@ -102,7 +103,7 @@ public:
     rclcpp::QoS points_qos(10);
     points_qos.best_effort();
     cloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
-      "/head_camera/depth_registered/points",
+      topic_path_depth_ ,
       points_qos,
       std::bind(&BasicGraspingPerception::cloud_callback, this, _1));
 
@@ -249,6 +250,8 @@ private:
   }
 
   bool debug_;
+  // Topic name of the pointcloud to be subscribed.
+  std::string topic_path_depth_;
 
   std::shared_ptr<tf2_ros::Buffer> buffer_;
   std::shared_ptr<tf2_ros::TransformListener> listener_;

--- a/src/basic_grasping_perception.cpp
+++ b/src/basic_grasping_perception.cpp
@@ -133,7 +133,7 @@ private:
       boost::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
     pcl::fromROSMsg(*msg, *cloud);
 
-    RCLCPP_DEBUG(LOGGER, "Cloud recieved with %d points.", static_cast<int>(cloud->points.size()));
+    RCLCPP_DEBUG(LOGGER, "Cloud received with %d points.", static_cast<int>(cloud->points.size()));
 
     // Filter out noisy long-range points
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered(new pcl::PointCloud<pcl::PointXYZRGB>);
@@ -223,7 +223,7 @@ private:
       {
         find_objects_ = false;
         goal_handle->abort(result);
-        RCLCPP_ERROR(LOGGER, "Failed to get camera data in alloted time.");
+        RCLCPP_ERROR(LOGGER, "Failed to get camera data in allocated time.");
         return;
       }
     }

--- a/src/basic_grasping_perception.cpp
+++ b/src/basic_grasping_perception.cpp
@@ -130,7 +130,7 @@ private:
 
     // Convert to point cloud
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud =
-      std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+      boost::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
     pcl::fromROSMsg(*msg, *cloud);
 
     RCLCPP_DEBUG(LOGGER, "Cloud recieved with %d points.", static_cast<int>(cloud->points.size()));

--- a/src/object_support_segmentation.cpp
+++ b/src/object_support_segmentation.cpp
@@ -32,8 +32,8 @@
 #include "simple_grasping/object_support_segmentation.h"
 
 #include <Eigen/Eigen>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "boost/lexical_cast.hpp"
 
@@ -88,6 +88,15 @@ bool ObjectSupportSegmentation::segment(
   bool output_clouds)
 {
   RCLCPP_INFO(LOGGER, "object support segmentation starting...");
+
+  if (cloud->empty()) {
+    RCLCPP_ERROR(LOGGER, "Input pointcloud is empty.");
+    return false;
+  }
+  if (cloud->is_dense) {
+    RCLCPP_ERROR(LOGGER, "Input pointcloud is dense. Care removing NaN.");
+    return false;
+  }
 
   // process the cloud with a voxel grid
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered(new pcl::PointCloud<pcl::PointXYZRGB>);

--- a/src/object_support_segmentation.cpp
+++ b/src/object_support_segmentation.cpp
@@ -98,7 +98,7 @@ bool ObjectSupportSegmentation::segment(
 
   // remove support planes
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr non_horizontal_planes;
-  non_horizontal_planes = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+  non_horizontal_planes = boost::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
   std::vector<pcl::ModelCoefficients::Ptr> plane_coefficients;  // coefs of all planes found
   int thresh = cloud_filtered->points.size()/8;
   while (cloud_filtered->points.size() > 500)
@@ -111,7 +111,7 @@ bool ObjectSupportSegmentation::segment(
     segment_.segment(*inliers, *coefficients);
     // TODO(enhancement): make configurable?
     // TODO(enhancement): make this based on "can we grasp object"
-    if (inliers->indices.size() < static_cast<size_t>(thresh))
+    if (inliers->indices.size() < (size_t) thresh)
     {
       RCLCPP_DEBUG(LOGGER, "No more planes to remove.");
       break;


### PR DESCRIPTION
# Issue
- `ros2` branch on the upstream repo https://github.com/mikeferguson/simple_grasping doesn't seem to build on Ubuntu 20.04.
   <details><summary>Proof from CI</summary>
   
   ```
   # colcon build                                              
   Starting >>> simple_grasping                                                                          
   --- stderr: simple_grasping                                                             
   /cws/src/simple_grasping/src/object_support_segmentation.cpp: In member function ‘bool simple_grasping::ObjectSupportSegmentation::segment(const ConstPtr&, std::vector<grasping_msgs::msg::Object_<std::all
   ocator<void> > >&, std::vector<grasping_msgs::msg::Object_<std::allocator<void> > >&, pcl::PointCloud<pcl::PointXYZRGB>&, pcl::PointCloud<pcl::PointXYZRGB>&, bool)’:                                       
   /cws/src/simple_grasping/src/object_support_segmentation.cpp:101:79: error: no match for ‘operator=’ (operand types are ‘pcl::PointCloud<pcl::PointXYZRGB>::Ptr’ {aka ‘boost::shared_ptr<pcl::PointCloud<pcl
   ::PointXYZRGB> >’} and ‘std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGB> >’)       101 |   non_horizontal_planes = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
         |           ^
   In file included from /usr/include/pcl-1.10/pcl/pcl_macros.h:69,                  
                    from /usr/include/pcl-1.10/pcl/pcl_base.h:46,                    
                    from /usr/include/pcl-1.10/pcl/common/io.h:46,                   
                    from /cws/src/simple_grasping/include/simple_grasping/object_support_segmentation.h:39,                  
                    from /cws/src/simple_grasping/src/object_support_segmentation.cpp:32:                
   /usr/include/boost/smart_ptr/shared_ptr.hpp:547:18: note: candidate: ‘boost::shared_ptr<T>& boost::shared_ptr<T>::operator=(const boost::shared_ptr<T>&) [with T = pcl::PointCloud<pcl::PointXYZRGB>]’
     547 |     shared_ptr & operator=( shared_ptr const & r ) BOOST_SP_NOEXCEPT
         |                  ^~~~~~~~               
   /usr/include/boost/smart_ptr/shared_ptr.hpp:547:48: note:   no known conversion for argument 1 from ‘std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGB> >’ to ‘const boost::shared_ptr<pcl::PointCloud<pcl::P
   ointXYZRGB> >&’     
     547 |     shared_ptr & operator=( shared_ptr const & r ) BOOST_SP_NOEXCEPT      
         |                             ~~~~~~~~~~~~~~~~~~~^                          
   /usr/include/boost/smart_ptr/shared_ptr.hpp:556:18: note: candidate: ‘template<class Y> boost::shared_ptr<T>& boost::shared_ptr<T>::operator=(const boost::shared_ptr<Y>&) [with Y = Y; T = pcl::PointCloud<
   
    :
    
   /usr/include/boost/smart_ptr/shared_ptr.hpp:683:29: note:   no known conversion for argument 1 from ‘std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGB> >’ to ‘boost::detail::sp_nullptr_t’ {aka ‘std::nullpt
   r_t’}
     683 |     shared_ptr & operator=( boost::detail::sp_nullptr_t ) BOOST_SP_NOEXCEPT
         |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
   make[2]: *** [CMakeFiles/simple_grasping.dir/build.make:76: CMakeFiles/simple_grasping.dir/src/object_support_segmentation.cpp.o] Error 1
   make[1]: *** [CMakeFiles/Makefile2:163: CMakeFiles/simple_grasping.dir/all] Error 2
   make: *** [Makefile:141: all] Error 2
   ---
   Failed   <<< simple_grasping [7.78s, exited with code 2]
   
   Summary: 0 packages finished [7.91s]
     1 package failed: simple_grasping
     1 package had stderr output: simple_grasping
   ```
   Same can be seen on GHA result on my repo in [a Foxy job](https://github.com/130s/simple_grasping/actions/runs/4748010860/jobs/8433670543#step:3:1559), but in the same run, a [Humble job passed](https://github.com/130s/simple_grasping/actions/runs/4748010860/jobs/8433670648).
   </details>
- CI is missing on this forked repo nor on the upstream.
- <s>https://github.com/mikeferguson/simple_grasping/pull/7 seems nice, may be valuable for my immediate usecase, but it's targeted at ROS1, and got stale.</s> --> Omitted as the functionality hasn't been validated on the author's env.
- Add a config option for the time to wait before aborting a request to detect graspable obj. On my platform the hardcoded 3.0 secs is too short before an obj to be detected.

# Branches
- Target: Made a new branch `foxy-devel` (assuming maintainers on the upstream repo aren't interested in maintaining Ubuntu 20.04 ver.)

# Post-merge plan
For 20.04 changes, we should ask the upstream maintainers if they're open to branch off for Ubuntu 20.04, but I doubt there's high chance. Worst case 20.04 branch can stay in the fork (here).

